### PR TITLE
Rails.application.assets is nil if config.assets.compile = false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 spec/dummy_app/public/*
+.idea

--- a/lib/asset_symlink.rb
+++ b/lib/asset_symlink.rb
@@ -4,7 +4,12 @@ require 'fileutils'
 module AssetSymlink
   def self.execute config
     normalize_configuration(config).each do |private_name, public_name|
-      digested_location = Rails.root.join('public','assets', Rails.application.assets.find_asset(private_name).digest_path)
+      asset = if !Rails.application.assets.nil?
+        Rails.application.assets.find_asset(private_name).digest_path
+      else
+        Rails.application.assets_manifest.assets[private_name]
+      end
+      digested_location = Rails.root.join('public','assets', asset)
       public_location = Rails.root.join('public','assets',public_name)
       if File.dirname(public_name) != '.'
         FileUtils.mkdir_p(File.dirname(public_location))


### PR DESCRIPTION
Deploying with config.assets.compile = false leads to an error since Rails.application.assets is nil then.

A check is added, and assets_manifest is used when necessary.